### PR TITLE
lookup contacts by MD5 hashed email

### DIFF
--- a/lib/fullcontact/client/person.rb
+++ b/lib/fullcontact/client/person.rb
@@ -19,6 +19,24 @@ module FullContact
         get('person', options)
       end
 
+      # Public: Uses the person method to request more information about a specific person by email_MD5 hash
+      #
+      # email_MD5   - The email address as MD5 hash of the person being looked up.
+      # options - Hash containing additional arguments (optional) (default: {})
+      #           :timeOutSeconds - Wait for specified time, before returning a 202 (optional)
+      #           :queue          - Enqueue this email for indexing (optional)
+      #           :callback       - If specified, the response will be wrapped as JSONP in a function call. (optional)
+      #           :webhookUrl     - Delivers lookup response at specified url (required for webhook calls)
+      #           :webhookId      - Id for tracking the webhook
+      #
+      # Example
+      #
+      #   response = FullContact.lookup_by_email_MD5('79d083b578589d5809922254639f6d99')
+      def lookup_by_email_MD5(email_MD5, options = {})
+        options[:emailMD5] = email_MD5
+        get('person', options)
+      end
+
       # Public: Uses the person method to request more information about a specific person by phone
       #
       # phone   - The phone number of the person being looked up.

--- a/lib/fullcontact/version.rb
+++ b/lib/fullcontact/version.rb
@@ -1,3 +1,3 @@
 module FullContact
-	VERSION = "0.3.2"
+	VERSION = "0.4.0"
 end

--- a/spec/fullcontact/client/person_spec.rb
+++ b/spec/fullcontact/client/person_spec.rb
@@ -23,6 +23,19 @@ describe FullContact::Client::Person do
     end
   end
 
+  describe "#lookup_by_email_MD5" do
+    before do
+      stub_get("person.json").
+        with(:query => { :apiKey => "api_key", :emailMD5 => '12345'}).
+        to_return(:body => fixture("person.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+    end
+
+    it "should get the list of contact lists" do
+      @client.lookup_by_email_MD5('12345')
+      a_get("person.json").with(:query => { :apiKey => "api_key", :emailMD5 => '12345' }).should have_been_made
+    end
+  end
+
   describe "#lookup_by_phone" do
     before do
       stub_get("person.json").


### PR DESCRIPTION
Hey Jai,

I know you didn't work on this software for a couple years but we still use and love it.
I added a new lookup for MD5 hashed emails. Would you consider merging this pull request?
Here is the documentation on [FullContact](https://www.fullcontact.com/blog/social-media-profiles-from-email-md5-hash/)

Thank you,
/Thomas, Mynewsdesk
